### PR TITLE
Use Python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Mac OS and Windows Subsystem for Linux.
 Please run the following commands to create a conda environment:
 
 ```bash
-conda create -n asqlcell -c conda-forge nodejs=18.15 python=3.10 jupyterlab=3.6 jupyter_packaging=0.12
+conda create -n asqlcell -c conda-forge nodejs=18.15 python=3.8 jupyterlab=3.6 jupyter_packaging=0.12
 conda activate asqlcell
 ```
 

--- a/asqlcell/chart.py
+++ b/asqlcell/chart.py
@@ -1,4 +1,4 @@
-from typing import Optional, TypedDict
+from typing import List, Optional, TypedDict
 
 from strenum import StrEnum
 
@@ -24,7 +24,7 @@ class ChartConfig(TypedDict):
     color: Optional[str]
     theta: Optional[str]
     aggregation: Optional[str]
-    subtype: list[str]
+    subtype: List[str]
     sort: Optional[str]
     height: int
     width: int

--- a/asqlcell/magic.py
+++ b/asqlcell/magic.py
@@ -1,3 +1,7 @@
+import json
+from typing import Union
+
+import requests
 from IPython.core.display import HTML
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.core.magic import Magics, cell_magic, line_magic, magics_class
@@ -5,8 +9,6 @@ from IPython.core.magic_arguments import argument, magic_arguments, parse_argstr
 from IPython.display import display
 from pandas import DataFrame
 from sqlalchemy import Connection
-import requests
-import json
 
 from asqlcell.utils import get_cell_id, get_duckdb_result
 from asqlcell.widget import SqlCellWidget
@@ -76,7 +78,7 @@ class SqlMagics(Magics):
         display(HTML(""), display_id=widget.cell_id)
         return widget
 
-    def _get_widget(self, var_name: str) -> SqlCellWidget | None:
+    def _get_widget(self, var_name: str) -> Union[SqlCellWidget, None]:
         """
         Get sql cell widget variable by the given name and type. None will be returned if type is incorrect.
         """
@@ -100,7 +102,7 @@ class SqlMagics(Magics):
         return var
 
     def displayAns(self, q, a):
-        from IPython.display import display, Markdown
+        from IPython.core.display import Markdown, display
 
         display(Markdown(f"Question: {q}\nAnswer: " + a))
 

--- a/asqlcell/utils.py
+++ b/asqlcell/utils.py
@@ -1,5 +1,3 @@
-import json
-
 import duckdb
 import numpy as np
 import pandas as pd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["jupyter_packaging==0.7.9", "jupyterlab==3.*", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging>=0.12", "jupyterlab==3.*", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
We should not use Python 3.10 as the minimum requirement for asqlcell.

Downgrade to Python 3.8 with annotatoin fixing.